### PR TITLE
fix phpdoc for getUserByIdentifier

### DIFF
--- a/src/Authorize/UserVerifierInterface.php
+++ b/src/Authorize/UserVerifierInterface.php
@@ -20,7 +20,7 @@ interface UserVerifierInterface
      *
      * @param string $identifier
      *
-     * @return null|User
+     * @return null|\Illuminate\Database\Eloquent\Model
      */
     public function getUserByIdentifier($identifier);
 }


### PR DESCRIPTION
Current phpdoc refers to RTLer\Oauth2\Authorize\User which doesn't exist
